### PR TITLE
Fix for the name change bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Three services are started : Acc, Environnemental and Time.
 For testing the sketch, you can download on the playstore the "BLueNRG" application provided by STMicroelectronics.
 Launch the application and enable Bluetooth on your smartphone. Connect it to the BLueNRG device. You will see all the services,
 you can click on each one and read the data.
+Pay attention that the device name can't be more than 7 characters long. If the string passed to the begin function is longer, it is 
+automatically trimmed to the first 7 characters.
+The BlueNRG app expects "BlueNRG" as device name, using anything else will make the device not connectable.
 
 
 The SPBTLE-RF uses SPI. You need to configure the pin used for spi link.

--- a/examples/SPBTLE_SensorDemo/SPBTLE_SensorDemo.ino
+++ b/examples/SPBTLE_SensorDemo/SPBTLE_SensorDemo.ino
@@ -17,6 +17,11 @@
  Environnemental values (Temperature, humidity and pressure) are updated each seconds.
  Each minute a notification is sent to the user and seconds can be read.
 
+ Pay attention that the device name can't be more than 7 characters long. If the string 
+ passed to the begin function is longer, it is automatically trimmed to the first 7 characters.
+ The BlueNRG app expects "BlueNRG" as device name, using anything else will make the device 
+ not connectable.
+
  */
 
 #include <SPI.h>
@@ -39,7 +44,7 @@ SPIClass BTLE_SPI(PIN_BLE_SPI_MOSI, PIN_BLE_SPI_MISO, PIN_BLE_SPI_SCK);
 // Configure BTLE pins
 SPBTLERFClass BTLE(&BTLE_SPI, PIN_BLE_SPI_nCS, PIN_BLE_SPI_IRQ, PIN_BLE_SPI_RESET, PIN_BLE_LED);
 
-const char *name = "BlueNRG";
+const char *name = "BlueNRG"; //Should be at most 7 characters
 uint8_t SERVER_BDADDR[] = {0x12, 0x34, 0x00, 0xE1, 0x80, 0x03};
 
 AxesRaw_t axes_data;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=STM32duino SPBTLE-RF
-version=1.0.2
+version=1.0.3
 author=STMicroelectronics, AMS, Wi6Labs
 maintainer=stm32duino
 sentence=This library includes drivers for ST's BlueNRG/BlueNRG-MS Bluetooth Low Energy device.

--- a/src/sensor_service.cpp
+++ b/src/sensor_service.cpp
@@ -126,6 +126,11 @@ tBleStatus SensorServiceClass::begin(const char *name, uint8_t addr[BDADDR_SIZE]
 
   uint8_t  hwVersion;
   uint16_t fwVersion;
+  
+  memset(dev_name, 0, sizeof(dev_name));
+  
+  dev_name[0] =AD_TYPE_COMPLETE_LOCAL_NAME;
+  strncpy(&dev_name[1], name, (strlen(name)<7) ? strlen(name) : 7);
 
   int ret;
 
@@ -190,7 +195,7 @@ tBleStatus SensorServiceClass::begin(const char *name, uint8_t addr[BDADDR_SIZE]
   }
 
   ret = aci_gatt_update_char_value(service_handle, dev_name_char_handle, 0,
-                                   strlen(name), (uint8_t *)name);
+                                   (strlen(name)<7) ? strlen(name) : 7, (uint8_t *)name);
 
   if(ret){
     PRINTF("aci_gatt_update_char_value failed.\n");
@@ -523,15 +528,13 @@ void SensorServiceClass::setConnectable(void)
 {
   tBleStatus ret;
 
-  const char local_name[] = {AD_TYPE_COMPLETE_LOCAL_NAME,'B','l','u','e','N','R','G'};
-
   if(set_connectable){
     /* disable scan response */
     hci_le_set_scan_resp_data(0,NULL);
     PRINTF("General Discoverable Mode.\n");
 
     ret = aci_gap_set_discoverable(ADV_IND, 0, 0, PUBLIC_ADDR, NO_WHITE_LIST_USE,
-                                   sizeof(local_name), local_name, 0, NULL, 0, 0);
+                                   strlen(dev_name), dev_name, 0, NULL, 0, 0);
     if (ret != BLE_STATUS_SUCCESS) {
       PRINTF("Error while setting discoverable mode (%d)\n", ret);
     }

--- a/src/sensor_service.h
+++ b/src/sensor_service.h
@@ -74,7 +74,8 @@
  * @{
  */
 /* Exported defines ----------------------------------------------------------*/
-
+// Default Name
+#define DEFAULT_DEVICE_NAME 'B','l','u','e','N','R','G'
 /**
  * @}
  */
@@ -149,7 +150,8 @@ class SensorServiceClass
     volatile uint32_t    press_data;
     volatile uint16_t   hum_data;
 
-    char dev_name[8];
+    char dev_name[8] =  {AD_TYPE_COMPLETE_LOCAL_NAME, DEFAULT_DEVICE_NAME};
+    uint8_t dev_nameLen;
     bool ledState = false;
     uint32_t previousMinuteValue = 0;
 };

--- a/src/sensor_service.h
+++ b/src/sensor_service.h
@@ -149,6 +149,7 @@ class SensorServiceClass
     volatile uint32_t    press_data;
     volatile uint16_t   hum_data;
 
+    char dev_name[8];
     bool ledState = false;
     uint32_t previousMinuteValue = 0;
 };


### PR DESCRIPTION
This PR should fix #6 with two limitations:

1. The device name can't be more than 7 characters long. If the string passed to the begin function is longer, it is automatically trimmed to 7 characters.
2. The android application designed to work with the SensorDemo example expects the name BlueNRG. Otherwise the device can't be opened.
  